### PR TITLE
Updated Legacy SDK docs

### DIFF
--- a/Docs/docs/legacy-sdk.md
+++ b/Docs/docs/legacy-sdk.md
@@ -1,11 +1,11 @@
 # Legacy SDK
 :::caution
-Support for VRChat's legacy SDK ('`.unitypackage`' SDK) is ending in 2022.
+Support for VRChat's legacy SDK ('`.unitypackage`' SDK) has ended with the start of 2023.
 * To create new projects, use the [Creator Companion](https://vcc.docs.vrchat.com/) or [a template](https://vcc.docs.vrchat.com/vpm/templates).
-* To update an old project, follow our [migration guide] by using the Creator Companion.
+* To update an old project, follow our [migration guide](https://vcc.docs.vrchat.com/vpm/migrating) by using the Creator Companion.
 :::
 The legacy SDK refers to the 'old' SDK package format distributed in files such as `VRCSDK3-WORLD-2022.07.26.21.44_Public.unitypackage`. If your project's `Assets` folder contains a folder named 'VRCSDK', then your project uses VRChat's legacy SDK.  
 
-New updates of the SDK will be available for the legacy SDK until 2022. Starting in 2023, new versions of the SDK will only be available through VRChat's  [Creator Companion](https://vcc.docs.vrchat.com/) or one of our [world or avatar templates](https://vcc.docs.vrchat.com/vpm/templates).
+The legacy SDK has now been deprecated. Currently new versions of the SDK are available through VRChat's  [Creator Companion](https://vcc.docs.vrchat.com/), one of our [world or avatar templates](https://vcc.docs.vrchat.com/vpm/templates) or directly as a VCC Package on [VRChat's Website](https://vrchat.com/home/download).
 
 To ensure that you'll be able to easily update your VRChat projects, please use one of the above methods to create new VRChat worlds. To upgrade your existing content, please use our [migration guide](https://vcc.docs.vrchat.com/vpm/migrating).


### PR DESCRIPTION
- fixed broken link to migration
- updated information about the legacy SDK now being deprecated
- added the direct VCC Package download as a way to get the SDK