### PR TITLE
Specify that the contents of package.json are required

### DIFF
--- a/Docs/docs/guides/create-listing.md
+++ b/Docs/docs/guides/create-listing.md
@@ -45,6 +45,6 @@ Take a look at the [example listing](https://vrchat-community.github.io/template
   * {package id}
     * versions
     * {version string in SemVer}
-      * {contents of `package.json`, which is a valid VPM manifest}
+      * {valid VPM manifest} _(the full contents of `package.json)_
 
 If you serve these from a publicly accessible URL, the Creator Companion will be able to read it and provide the packages listed inside.

--- a/Docs/docs/guides/create-listing.md
+++ b/Docs/docs/guides/create-listing.md
@@ -45,6 +45,6 @@ Take a look at the [example listing](https://vrchat-community.github.io/template
   * {package id}
     * versions
     * {version string in SemVer}
-      * {valid VPM manifest}
+      * {contents of `package.json`, which is a valid VPM manifest}
 
 If you serve these from a publicly accessible URL, the Creator Companion will be able to read it and provide the packages listed inside.


### PR DESCRIPTION
Many friends making their first vpm repository omits some properties of package.json and the repository is not working as expected so I added that the contents of package.json are required to reduce such a mistake.