### PR TITLE
Fixed syntax error

### DIFF
--- a/Docs/docs/vpm/templates.md
+++ b/Docs/docs/vpm/templates.md
@@ -45,12 +45,8 @@ The only required fields are "name" and "displayName" for now. Note that "defaul
 ```json
 {
 	"dependencies" : {
-		"com.vrchat.worlds" : {
-			"version" : "^3.1.x"
-		},
-		"com.mydomain.hype" : {
-			"version" : "1.0.x"
-		}
+		"com.vrchat.worlds" : "^3.1.x",
+		"com.mydomain.hype" : "1.0.x"
 	}
 }
 ```


### PR DESCRIPTION
The old code would have created the following error:

Failed to handle HTTP request: Unexpected character encountered while parsing value: {. Path 'dependencies['com.vrchat.worlds']', line 8, position 27.